### PR TITLE
Fix provider on ubuntu, cache bundler to speed up travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 ---
 language: ruby
+cache: bundler
 sudo: false
 notifications:
   slack: bloomberg-rnd:eHp3Czg42iGzaTgG8sAFeD9v

--- a/libraries/collectd_service.rb
+++ b/libraries/collectd_service.rb
@@ -97,6 +97,7 @@ module CollectdCookbook
 
           package new_resource.package_name do
             provider Chef::Provider::Package::Solaris if platform?('solaris2')
+            provider Chef::Provider::Package::Dpkg if platform?('ubuntu') && new_resource.package_source
             action :upgrade
             version new_resource.package_version
             source package_path

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'jbellone@bloomberg.net'
 license 'Apache 2.0'
 description 'Installs and configures the collectd monitoring daemon.'
 long_description 'Installs and configures the collectd monitoring daemon.'
-version '2.2.0'
+version '2.2.1'
 source_url 'https://github.com/bloomberg/collectd-cookbook'
 issues_url 'https://github.com/bloomberg/collectd-cookbook/issues'
 


### PR DESCRIPTION
Use dpkg provider instead of apt on ubuntu if package_source is given
cc @johnbellone 
