### PR TITLE
Handle User and group changes better

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -29,3 +29,12 @@ suites:
   - name: default
     run_list:
       - recipe[collectd::default]
+  - name: userchange
+    run_list:
+      - recipe[collectd::default]
+      - recipe[collectd::_test_plugin]
+    attributes:
+      collectd:
+        service_user: 'root'
+        service_group: 'root'
+

--- a/libraries/collectd_config.rb
+++ b/libraries/collectd_config.rb
@@ -7,7 +7,6 @@
 #
 require 'poise'
 
-
 module CollectdCookbook
   module Resource
     # A resource which manages collectd daemon configurations.
@@ -31,10 +30,10 @@ module CollectdCookbook
       attribute(:configuration, option_collector: true)
 
       # checks to see if the default attributes were changed
-      def name_check(key,other)
+      def name_check(key, other)
         if other == 'collectd'
-          c = Chef.node.fetch('collectd',{})
-          c.fetch(key,'collectd')
+          c = Chef.node.fetch('collectd', {})
+          c.fetch(key, 'collectd')
         else
           other
         end
@@ -94,8 +93,8 @@ module CollectdCookbook
 
           file new_resource.path do
             content new_resource.content
-            owner new_resource.name_check('service_user',new_resource.owner)
-            group new_resource.name_check('service_group',new_resource.group)
+            owner new_resource.name_check('service_user', new_resource.owner)
+            group new_resource.name_check('service_group', new_resource.group)
             mode new_resource.mode
           end
         end

--- a/libraries/collectd_config.rb
+++ b/libraries/collectd_config.rb
@@ -7,6 +7,7 @@
 #
 require 'poise'
 
+
 module CollectdCookbook
   module Resource
     # A resource which manages collectd daemon configurations.
@@ -28,6 +29,16 @@ module CollectdCookbook
       attribute(:mode, kind_of: String, default: '0644')
 
       attribute(:configuration, option_collector: true)
+
+      # checks to see if the default attributes were changed
+      def name_check(key,other)
+        if other == 'collectd'
+          c = Chef.node.fetch('collectd',{})
+          c.fetch(key,'collectd')
+        else
+          other
+        end
+      end
 
       # Produces collectd {configuration} elements from resource.
       # @return [String]
@@ -83,8 +94,8 @@ module CollectdCookbook
 
           file new_resource.path do
             content new_resource.content
-            owner new_resource.owner
-            group new_resource.group
+            owner new_resource.name_check('service_user',new_resource.owner)
+            group new_resource.name_check('service_group',new_resource.group)
             mode new_resource.mode
           end
         end

--- a/libraries/collectd_config.rb
+++ b/libraries/collectd_config.rb
@@ -23,21 +23,11 @@ module CollectdCookbook
       provides(:collectd_config)
 
       attribute(:path, kind_of: String, name_attribute: true)
-      attribute(:owner, kind_of: String, default: 'collectd')
-      attribute(:group, kind_of: String, default: 'collectd')
+      attribute(:owner, kind_of: String, default: lazy { node['collectd']['service_user'] || 'collectd' })
+      attribute(:group, kind_of: String, default: lazy { node['collectd']['service_group'] || 'collectd' })
       attribute(:mode, kind_of: String, default: '0644')
 
       attribute(:configuration, option_collector: true)
-
-      # checks to see if the default attributes were changed
-      def name_check(key, other)
-        if other == 'collectd'
-          c = Chef.node.fetch('collectd', {})
-          c.fetch(key, 'collectd')
-        else
-          other
-        end
-      end
 
       # Produces collectd {configuration} elements from resource.
       # @return [String]
@@ -93,8 +83,8 @@ module CollectdCookbook
 
           file new_resource.path do
             content new_resource.content
-            owner new_resource.name_check('service_user', new_resource.owner)
-            group new_resource.name_check('service_group', new_resource.group)
+            owner new_resource.owner
+            group new_resource.group
             mode new_resource.mode
           end
         end

--- a/libraries/collectd_config.rb
+++ b/libraries/collectd_config.rb
@@ -23,8 +23,8 @@ module CollectdCookbook
       provides(:collectd_config)
 
       attribute(:path, kind_of: String, name_attribute: true)
-      attribute(:owner, kind_of: String, default: lazy { node['collectd']['service_user'] || 'collectd' })
-      attribute(:group, kind_of: String, default: lazy { node['collectd']['service_group'] || 'collectd' })
+      attribute(:owner, kind_of: String, default: lazy { Chef.node.fetch('collectd', {}).fetch('service_user', 'collectd') })
+      attribute(:group, kind_of: String, default: lazy { Chef.node.fetch('collectd', {}).fetch('service_group', 'collectd') })
       attribute(:mode, kind_of: String, default: '0644')
 
       attribute(:configuration, option_collector: true)

--- a/libraries/collectd_plugin.rb
+++ b/libraries/collectd_plugin.rb
@@ -30,28 +30,18 @@ module CollectdCookbook
       # User which the configuration for {#plugin_name} is owned by.
       # Defaults to 'collectd'
       # @return [String]
-      attribute(:user, kind_of: String, default: 'collectd')
+      attribute(:user, kind_of: String, default: lazy { node['collectd']['service_user'] || 'collectd' })
 
       # @!attribute group
       # Group which the configuration for {#plugin_name} is owned by.
       # Defaults to 'collectd'
       # @return [String]
-      attribute(:group, kind_of: String, default: 'collectd')
+      attribute(:group, kind_of: String, default: lazy { node['collectd']['service_group'] || 'collectd' })
 
       # @!attribute options
       # Set of key-value options to configure the plugin.
       # @return [Hash, Mash]
       attribute(:options, option_collector: true)
-
-      # checks to see if the default attributes were changed
-      def name_check(key, other)
-        if other == 'collectd'
-          c = Chef.node.fetch('collectd', {})
-          c.fetch(key, 'collectd')
-        else
-          other
-        end
-      end
 
       # @return [String]
       def config_filename
@@ -62,8 +52,8 @@ module CollectdCookbook
         notifying_block do
           directory new_resource.directory do
             recursive true
-            owner new_resource.name_check('service_user', new_resource.user)
-            group new_resource.name_check('service_group', new_resource.group)
+            owner new_resource.user
+            group new_resource.group
             mode '0755'
           end
 

--- a/libraries/collectd_plugin.rb
+++ b/libraries/collectd_plugin.rb
@@ -30,13 +30,13 @@ module CollectdCookbook
       # User which the configuration for {#plugin_name} is owned by.
       # Defaults to 'collectd'
       # @return [String]
-      attribute(:user, kind_of: String, default: lazy { node['collectd']['service_user'] || 'collectd' })
+      attribute(:user, kind_of: String, default: lazy { Chef.node.fetch('collectd', {}).fetch('service_user', 'collectd') })
 
       # @!attribute group
       # Group which the configuration for {#plugin_name} is owned by.
       # Defaults to 'collectd'
       # @return [String]
-      attribute(:group, kind_of: String, default: lazy { node['collectd']['service_group'] || 'collectd' })
+      attribute(:group, kind_of: String, default: lazy { Chef.node.fetch('collectd', {}).fetch('service_group', 'collectd') })
 
       # @!attribute options
       # Set of key-value options to configure the plugin.

--- a/libraries/collectd_plugin.rb
+++ b/libraries/collectd_plugin.rb
@@ -44,10 +44,10 @@ module CollectdCookbook
       attribute(:options, option_collector: true)
 
       # checks to see if the default attributes were changed
-      def name_check(key,other)
+      def name_check(key, other)
         if other == 'collectd'
-          c = Chef.node.fetch('collectd',{})
-          c.fetch(key,'collectd')
+          c = Chef.node.fetch('collectd', {})
+          c.fetch(key, 'collectd')
         else
           other
         end
@@ -62,8 +62,8 @@ module CollectdCookbook
         notifying_block do
           directory new_resource.directory do
             recursive true
-            owner new_resource.name_check('service_user',new_resource.user)
-            group new_resource.name_check('service_group',new_resource.group)
+            owner new_resource.name_check('service_user', new_resource.user)
+            group new_resource.name_check('service_group', new_resource.group)
             mode '0755'
           end
 

--- a/libraries/collectd_plugin.rb
+++ b/libraries/collectd_plugin.rb
@@ -28,13 +28,13 @@ module CollectdCookbook
 
       # @!attribute user
       # User which the configuration for {#plugin_name} is owned by.
-      # Defaults to 'collectd.'
+      # Defaults to 'collectd'
       # @return [String]
       attribute(:user, kind_of: String, default: 'collectd')
 
       # @!attribute group
       # Group which the configuration for {#plugin_name} is owned by.
-      # Defaults to 'collectd.'
+      # Defaults to 'collectd'
       # @return [String]
       attribute(:group, kind_of: String, default: 'collectd')
 
@@ -42,6 +42,16 @@ module CollectdCookbook
       # Set of key-value options to configure the plugin.
       # @return [Hash, Mash]
       attribute(:options, option_collector: true)
+
+      # checks to see if the default attributes were changed
+      def name_check(key,other)
+        if other == 'collectd'
+          c = Chef.node.fetch('collectd',{})
+          c.fetch(key,'collectd')
+        else
+          other
+        end
+      end
 
       # @return [String]
       def config_filename
@@ -52,8 +62,8 @@ module CollectdCookbook
         notifying_block do
           directory new_resource.directory do
             recursive true
-            owner new_resource.user
-            group new_resource.group
+            owner new_resource.name_check('service_user',new_resource.user)
+            group new_resource.name_check('service_group',new_resource.group)
             mode '0755'
           end
 

--- a/libraries/collectd_plugin_file.rb
+++ b/libraries/collectd_plugin_file.rb
@@ -34,13 +34,13 @@ module CollectdCookbook
       # User which the configuration for {#plugin_name} is owned by.
       # Defaults to 'collectd.'
       # @return [String]
-      attribute(:user, kind_of: String, default: lazy { node['collectd']['service_user'] || 'collectd' })
+      attribute(:user, kind_of: String, default: lazy { Chef.node.fetch('collectd', {}).fetch('service_user', 'collectd') })
 
       # @!attribute group
       # Group which the configuration for {#plugin_name} is owned by.
       # Defaults to 'collectd.'
       # @return [String]
-      attribute(:group, kind_of: String, default: lazy { node['collectd']['service_group'] || 'collectd' })
+      attribute(:group, kind_of: String, default: lazy { Chef.node.fetch('collectd', {}).fetch('service_group', 'collectd') })
 
       # @!attribute cookbook
       # The name of the cookbook where template file lives

--- a/libraries/collectd_plugin_file.rb
+++ b/libraries/collectd_plugin_file.rb
@@ -34,13 +34,13 @@ module CollectdCookbook
       # User which the configuration for {#plugin_name} is owned by.
       # Defaults to 'collectd.'
       # @return [String]
-      attribute(:user, kind_of: String, default: 'collectd')
+      attribute(:user, kind_of: String, default: lazy { node['collectd']['service_user'] || 'collectd' })
 
       # @!attribute group
       # Group which the configuration for {#plugin_name} is owned by.
       # Defaults to 'collectd.'
       # @return [String]
-      attribute(:group, kind_of: String, default: 'collectd')
+      attribute(:group, kind_of: String, default: lazy { node['collectd']['service_group'] || 'collectd' })
 
       # @!attribute cookbook
       # The name of the cookbook where template file lives
@@ -62,28 +62,18 @@ module CollectdCookbook
         ::File.join(directory, "#{plugin_name}_#{plugin_instance_name}.conf")
       end
 
-      # checks to see if the default attributes were changed
-      def name_check(key, other)
-        if other == 'collectd'
-          c = Chef.node.fetch('collectd', {})
-          c.fetch(key, 'collectd')
-        else
-          other
-        end
-      end
-
       action(:create) do
         notifying_block do
           directory new_resource.directory do
             recursive true
-            owner new_resource.name_check('service_user', new_resource.user)
-            group new_resource.name_check('service_group', new_resource.group)
+            owner new_resource.user
+            group new_resource.group
             mode '0755'
           end
 
           template new_resource.config_filename do
-            owner new_resource.name_check('service_user', new_resource.user)
-            group new_resource.name_check('service_group', new_resource.group)
+            owner new_resource.user
+            group new_resource.group
             cookbook new_resource.cookbook
             source new_resource.source
             variables new_resource.variables

--- a/libraries/collectd_plugin_file.rb
+++ b/libraries/collectd_plugin_file.rb
@@ -62,18 +62,28 @@ module CollectdCookbook
         ::File.join(directory, "#{plugin_name}_#{plugin_instance_name}.conf")
       end
 
+      # checks to see if the default attributes were changed
+      def name_check(key,other)
+        if other == 'collectd'
+          c = Chef.node.fetch('collectd',{})
+          c.fetch(key,'collectd')
+        else
+          other
+        end
+      end
+
       action(:create) do
         notifying_block do
           directory new_resource.directory do
             recursive true
-            owner new_resource.user
-            group new_resource.group
+            owner new_resource.name_check('service_user',new_resource.user)
+            group new_resource.name_check('service_group',new_resource.group)
             mode '0755'
           end
 
           template new_resource.config_filename do
-            owner new_resource.user
-            group new_resource.group
+            owner new_resource.name_check('service_user',new_resource.user)
+            group new_resource.name_check('service_group',new_resource.group)
             cookbook new_resource.cookbook
             source new_resource.source
             variables new_resource.variables

--- a/libraries/collectd_plugin_file.rb
+++ b/libraries/collectd_plugin_file.rb
@@ -63,10 +63,10 @@ module CollectdCookbook
       end
 
       # checks to see if the default attributes were changed
-      def name_check(key,other)
+      def name_check(key, other)
         if other == 'collectd'
-          c = Chef.node.fetch('collectd',{})
-          c.fetch(key,'collectd')
+          c = Chef.node.fetch('collectd', {})
+          c.fetch(key, 'collectd')
         else
           other
         end
@@ -76,14 +76,14 @@ module CollectdCookbook
         notifying_block do
           directory new_resource.directory do
             recursive true
-            owner new_resource.name_check('service_user',new_resource.user)
-            group new_resource.name_check('service_group',new_resource.group)
+            owner new_resource.name_check('service_user', new_resource.user)
+            group new_resource.name_check('service_group', new_resource.group)
             mode '0755'
           end
 
           template new_resource.config_filename do
-            owner new_resource.name_check('service_user',new_resource.user)
-            group new_resource.name_check('service_group',new_resource.group)
+            owner new_resource.name_check('service_user', new_resource.user)
+            group new_resource.name_check('service_group', new_resource.group)
             cookbook new_resource.cookbook
             source new_resource.source
             variables new_resource.variables

--- a/libraries/collectd_service.rb
+++ b/libraries/collectd_service.rb
@@ -21,12 +21,12 @@ module CollectdCookbook
       # @!attribute user
       # User to run the collectd daemon as. Defaults to 'collectd.'
       # @return [String]
-      attribute(:user, kind_of: String, default: 'collectd')
+      attribute(:user, kind_of: String, default: lazy { node['collectd']['service_user'] || 'collectd' })
 
       # @!attribute group
       # Group to run the collectd daemon as. Defaults to 'collectd.'
       # @return [String]
-      attribute(:group, kind_of: String, default: 'collectd')
+      attribute(:group, kind_of: String, default: lazy { node['collectd']['service_group'] || 'collectd' })
 
       # @!attribute directory
       # The working directory for the service. Defaults to the data

--- a/libraries/collectd_service.rb
+++ b/libraries/collectd_service.rb
@@ -21,12 +21,12 @@ module CollectdCookbook
       # @!attribute user
       # User to run the collectd daemon as. Defaults to 'collectd.'
       # @return [String]
-      attribute(:user, kind_of: String, default: lazy { node['collectd']['service_user'] || 'collectd' })
+      attribute(:user, kind_of: String, default: lazy { Chef.node.fetch('collectd', {}).fetch('service_user', 'collectd') })
 
       # @!attribute group
       # Group to run the collectd daemon as. Defaults to 'collectd.'
       # @return [String]
-      attribute(:group, kind_of: String, default: lazy { node['collectd']['service_group'] || 'collectd' })
+      attribute(:group, kind_of: String, default: lazy { Chef.node.fetch('collectd', {}).fetch('service_group', 'collectd') })
 
       # @!attribute directory
       # The working directory for the service. Defaults to the data

--- a/recipes/_test_plugin.rb
+++ b/recipes/_test_plugin.rb
@@ -1,0 +1,3 @@
+collectd_plugin 'network'
+
+

--- a/recipes/_test_plugin.rb
+++ b/recipes/_test_plugin.rb
@@ -1,3 +1,1 @@
 collectd_plugin 'network'
-
-

--- a/test/integration/userchange/serverspec/default_spec.rb
+++ b/test/integration/userchange/serverspec/default_spec.rb
@@ -37,3 +37,10 @@ describe file('/etc/collectd.conf') do
   it { should_not contain 'WriteQueueLimitLow' }
   it { should contain 'Include "/etc/collectd.d/*.conf"' }
 end
+
+describe file('/etc/collectd.d/network.conf') do
+  it { should be_file }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+  it { should contain 'LoadPlugin "network"' }
+end

--- a/test/integration/userchange/serverspec/default_spec.rb
+++ b/test/integration/userchange/serverspec/default_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe group('root') do
+  it { should exist }
+end
+
+describe user('root') do
+  it { should exist }
+end
+
+describe service('collectd') do
+  it { should be_enabled }
+  it { should be_running }
+end
+
+describe file('/var/lib/collectd') do
+  it { should be_directory }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+end
+
+describe file('/etc/collectd.d') do
+  it { should be_directory }
+  it { should be_owned_by 'root' }
+  it { should be_grouped_into 'root' }
+end
+
+describe file('/etc/collectd.conf') do
+  it { should be_file }
+  it { should be_owned_by 'root'}
+  it { should be_grouped_into 'root' }
+  it { should contain 'Interval 10' }
+  it { should contain 'ReadThreads 5' }
+  it { should contain 'WriteThreads 5' }
+  it { should_not contain 'Timeout' }
+  it { should_not contain 'WriteQueueLimitHigh' }
+  it { should_not contain 'WriteQueueLimitLow' }
+  it { should contain 'Include "/etc/collectd.d/*.conf"' }
+end


### PR DESCRIPTION
We ran into some issues when configuring collectd to user the root user and root group for running collectd.  not all of the recipe honors the change in the user, specifically the LWRP code in the library directory hard codes the defaults as 'collectd' and as such fails when the user is not present.  This is my attempt at pulling proper defaults from the attributes file.  It is not as pretty as I would like, so if you have suggestions on how to make it cleaner, please comment.  
