### PR TITLE
fix FQDN hostname lookup

### DIFF
--- a/templates/default/systemd.erb
+++ b/templates/default/systemd.erb
@@ -1,5 +1,6 @@
 [Unit]
 Description=<%= @name %>
+After=network.target
 
 [Service]
 Type=forking


### PR DESCRIPTION
* fixes similar errors on machines which is setting up their hostnames
  with dns (instead of `/etc/hosts` file)

    collectd[980]: Looking up "server" failed. You
    have set the "FQDNLookup" option, but I cannot resolve my hostname to a
    fully qualified domain name. Please fix the network configuration.